### PR TITLE
feat: added user defined variables for Turbo customization

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -408,7 +408,7 @@ resource "aws_iam_role_policy_attachment" "golang_lambda_policy_attach" {
 // download lambda_function.zip from turbo deploy v0.1.0 pre-release
 
 data "http" "latest_release" {
-  url = "https://api.github.com/repos/frgrisk/turbo-deploy/releases/tags/v0.1.1"
+  url = "https://api.github.com/repos/frgrisk/turbo-deploy/releases/tags/v0.1.2"
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -419,6 +419,7 @@ resource "aws_lambda_function" "database_lambda" {
     variables = {
       MY_CUSTOM_ENV = "Lambda"
       MY_AMI_ATTR   = jsonencode(var.ec2_attributes)
+      MY_REGION     = data.aws_region.current.name
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -363,8 +363,8 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
         Resource = "*"
       },
       {
-        Effect   = "Allow",
-        Action   = [
+        Effect = "Allow",
+        Action = [
           "route53:GetHostedZone",
           "route53:ListResourceRecordSets",
           "route53:ChangeResourceRecordSets",
@@ -485,8 +485,8 @@ resource "aws_lambda_event_source_mapping" "terraform_event_mapping" {
 }
 
 resource "aws_s3_object" "file_upload" {
-  bucket  = "${aws_s3_bucket.s3_terraform_state.bucket}"
-  key     = "user-data-scripts/user-data.sh"
+  bucket       = aws_s3_bucket.s3_terraform_state.bucket
+  key          = "user-data-scripts/user-data.sh"
   content_type = "text/plain"
-  content = var.user_scripts
+  content      = var.user_scripts
 }

--- a/main.tf
+++ b/main.tf
@@ -345,6 +345,7 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
           "ec2:DeregisterImage",
           "ec2:DescribeImages",
           // Key pairs
+          "ec2:ImportKeyPair",
           "ec2:CreateKeyPair",
           "ec2:DeleteKeyPair",
           "ec2:DescribeKeyPairs",
@@ -479,6 +480,7 @@ resource "aws_lambda_function" "my_tf_function" {
       SECURITY_GROUP_ID          = var.security_group_id != null ? var.security_group_id : ""
       PUBLIC_SUBNET_ID           = length(var.public_subnet_ids) > 0 ? element(var.public_subnet_ids, 0) : ""
       HOSTED_ZONE_ID             = var.zone_id
+      PUBLIC_KEY                 = aws_key_pair.admin_key.key_name
     }
   }
   depends_on = [
@@ -498,4 +500,9 @@ resource "aws_s3_object" "file_upload" {
   key          = "user-data-scripts/user-data.sh"
   content_type = "text/plain"
   content      = var.user_scripts
+}
+
+resource "aws_key_pair" "admin_key" {
+  key_name   = "admin_key"
+  public_key = var.public_key
 }

--- a/main.tf
+++ b/main.tf
@@ -391,13 +391,18 @@ resource "null_resource" "download_lambda_zip" {
     download_url = local.download_url
   }
 
-  provisioner "local-exec" {
-    command = <<EOF
-      mkdir -p ${path.module}/lambda_zip &&
-      chmod +x ${path.module}/lambda_zip/download_lambda.sh &&
-      ${path.module}/lambda_zip/download_lambda.sh '${local.download_url}' '${path.module}/lambda_zip/lambda_function.zip'
-    EOF
-  }
+  # provisioner "local-exec" {
+  #   command = <<EOF
+  #     mkdir -p ${path.module}/lambda_zip &&
+  #     mkdir -p ${path.module}/modified_lambda_zip &&
+  #     chmod +x ${path.module}/lambda_zip/download_lambda.sh &&
+  #     ${path.module}/lambda_zip/download_lambda.sh '${local.download_url}' '${path.module}/lambda_zip/lambda_function.zip' &&
+  #     unzip ${path.module}/lambda_zip/lambda_function.zip -d ${path.module}/modified_lambda_zip/ &&
+  #     sed -i 's/ami-0d28f30b30f1f3cb9/ami-07ac2451de5d161f6/g' ${path.module}/modified_lambda_zip/config.json &&
+  #     zip -j ${path.module}/modified_lambda_zip/lambda_function.zip ${path.module}/modified_lambda_zip/bootstrap ${path.module}/modified_lambda_zip/config.json &&
+  #     rm ${path.module}/modified_lambda_zip/bootstrap ${path.module}/modified_lambda_zip/config.json
+  #   EOF
+  # }
 
   depends_on = [data.http.latest_release]
 }
@@ -413,6 +418,7 @@ resource "aws_lambda_function" "database_lambda" {
   environment {
     variables = {
       MY_CUSTOM_ENV = "Lambda"
+      MY_AMI_ATTR   = jsonencode(var.ec2_attributes)
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -412,22 +412,21 @@ resource "null_resource" "download_lambda_zip" {
     download_url = local.download_url
   }
 
-  # provisioner "local-exec" {
-  #   command = <<EOF
-  #     mkdir -p ${path.module}/lambda_zip &&
-  #     mkdir -p ${path.module}/modified_lambda_zip &&
-  #     chmod +x ${path.module}/lambda_zip/download_lambda.sh &&
-  #     ${path.module}/lambda_zip/download_lambda.sh '${local.download_url}' '${path.module}/lambda_zip/lambda_function.zip' &&
-  #   EOF
-  # }
+  provisioner "local-exec" {
+    command = <<EOF
+      mkdir -p ${path.cwd}/lambda_zip &&
+      chmod +x ${path.module}/lambda_zip/download_lambda.sh &&
+      ${path.module}/lambda_zip/download_lambda.sh '${local.download_url}' '${path.cwd}/lambda_zip/lambda_function.zip'
+    EOF
+  }
 
   depends_on = [data.http.latest_release]
 }
 
 resource "aws_lambda_function" "database_lambda" {
   function_name    = var.database_lambda_function_name
-  filename         = "${path.module}/${var.lambda_function_zip_path}"
-  source_code_hash = fileexists("${path.module}/${var.lambda_function_zip_path}") ? filebase64sha256("${path.module}/${var.lambda_function_zip_path}") : ""
+  filename         = "${path.cwd}/${var.lambda_function_zip_path}"
+  source_code_hash = fileexists("${path.cwd}/${var.lambda_function_zip_path}") ? filebase64sha256("${path.cwd}/${var.lambda_function_zip_path}") : ""
   handler          = "bootstrap"
   runtime          = "provided.al2023"
   role             = aws_iam_role.golang_lambda_exec.arn

--- a/main.tf
+++ b/main.tf
@@ -439,10 +439,13 @@ resource "aws_lambda_function" "database_lambda" {
 
   environment {
     variables = {
-      MY_CUSTOM_ENV = "Lambda"
-      MY_AMI_ATTR   = jsonencode(var.ec2_attributes)
-      MY_REGION     = data.aws_region.current.name
-      DOMAIN_NAME   = data.aws_route53_zone.zone_name.name
+      MY_CUSTOM_ENV        = "Lambda"
+      MY_AMI_ATTR          = jsonencode(var.ec2_attributes)
+      MY_REGION            = data.aws_region.current.name
+      ROUTE53_DOMAIN_NAME  = data.aws_route53_zone.zone_name.name
+      WEBSERVER_HOSTNAME   = var.turbo_deploy_hostname
+      WEBSERVER_HTTP_PORT  = var.turbo_deploy_http_port
+      WEBSERVER_HTTPS_PORT = var.turbo_deploy_https_port
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -406,7 +406,7 @@ resource "aws_iam_role_policy_attachment" "golang_lambda_policy_attach" {
 // download lambda_function.zip from turbo deploy v0.1.0 pre-release
 
 data "http" "latest_release" {
-  url = "https://api.github.com/repos/frgrisk/turbo-deploy/releases/tags/v0.1.0"
+  url = "https://api.github.com/repos/frgrisk/turbo-deploy/releases/tags/v0.1.1"
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,12 @@ terraform {
 
 data "aws_region" "current" {}
 
+// retrieve the zone name
+data "aws_route53_zone" "zone_name" {
+  zone_id      = var.zone_id
+  private_zone = false
+}
+
 // create an s3 bucket for lambda tf state
 resource "aws_s3_bucket" "s3_terraform_state" {
   bucket        = var.s3_tf_bucket_name
@@ -372,7 +378,7 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
           "route53:ListTagsForResource",
         ],
         Resource = [
-          "arn:aws:route53:::hostedzone/${var.zone_id}",
+          "${data.aws_route53_zone.zone_name.arn}",
           "arn:aws:route53:::change/*",
         ],
       },
@@ -436,6 +442,7 @@ resource "aws_lambda_function" "database_lambda" {
       MY_CUSTOM_ENV = "Lambda"
       MY_AMI_ATTR   = jsonencode(var.ec2_attributes)
       MY_REGION     = data.aws_region.current.name
+      DOMAIN_NAME   = data.aws_route53_zone.zone_name.name
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -268,7 +268,7 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
       },
       {
         Effect   = "Allow",
-        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:GetObjectTagging"],
         Resource = "arn:aws:s3:::${var.s3_tf_bucket_name}/*"
       },
       {
@@ -464,4 +464,11 @@ resource "aws_lambda_event_source_mapping" "terraform_event_mapping" {
   event_source_arn  = aws_dynamodb_table.http_crud_backend.stream_arn
   function_name     = aws_lambda_function.my_tf_function.arn
   starting_position = "LATEST"
+}
+
+resource "aws_s3_object" "file_upload" {
+  bucket  = "${aws_s3_bucket.s3_terraform_state.bucket}"
+  key     = "user-data-scripts/user-data.sh"
+  content_type = "text/plain"
+  content = var.user_scripts
 }

--- a/main.tf
+++ b/main.tf
@@ -308,6 +308,7 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
           "ec2:DescribeInstanceTypes",
           "ec2:CreateTags",
           "ec2:DescribeTags",
+          "ec2:DeleteTags",
           // Network interfaces
           "ec2:DescribeVpcs",
           "ec2:CreateNetworkInterface",

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "ecr_repository_name" {
   description = "Name of the ecr repository to hold lambda image"
   type        = string
-  default     = "my-tf-function"
+  default     = null
 }
 
 variable "security_group_id" {
@@ -86,4 +86,13 @@ variable "terraform_lambda_function_name" {
   description = "Name of the terraform lambda function"
   type        = string
   default     = "MyTerraformFunction"
+}
+
+variable "ec2_attributes" {
+  description = "EC2 attributes that can be modified (e.g. AMI, Server Type, etc...)"
+  type        = map(list(string))
+  default = {
+    ServerSizes = ["t3.medium"]
+    Amis        = ["ami-07ac2451de5d161f6"]
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -96,3 +96,9 @@ variable "ec2_attributes" {
     Amis        = ["ami-07ac2451de5d161f6"]
   }
 }
+
+variable "user_scripts" {
+  description = "The user data to use when launching the instance"
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -126,3 +126,9 @@ variable "turbo_deploy_https_port" {
   type        = string
   default     = "4443"
 }
+
+variable "public_key" {
+  description = "The default public key to be added to all deployed instances"
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -102,3 +102,9 @@ variable "user_scripts" {
   type        = string
   default     = ""
 }
+
+variable "zone_id" {
+  description = "The ID of the hosted zone that will be used for DNS"
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -108,3 +108,21 @@ variable "zone_id" {
   type        = string
   default     = null
 }
+
+variable "turbo_deploy_hostname" {
+  description = "The hostname of the web application that will host the frontend, required for cors"
+  type        = string
+  default     = "turbo-deploy"
+}
+
+variable "turbo_deploy_http_port" {
+  description = "The port of the web application that will host the frontend, required for cors. Choose a non privileged port (>1023)"
+  type        = string
+  default     = "4080"
+}
+
+variable "turbo_deploy_https_port" {
+  description = "The port of the web application that will host the frontend, required for cors. Choose a non privileged port (>1023)"
+  type        = string
+  default     = "4443"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -89,11 +89,11 @@ variable "terraform_lambda_function_name" {
 }
 
 variable "ec2_attributes" {
-  description = "EC2 attributes that can be modified (e.g. AMI, Server Type, etc...)"
+  description = "EC2 attributes that can be modified (e.g. AMI, Server Type)"
   type        = map(list(string))
   default = {
     ServerSizes = ["t3.medium"]
-    Amis        = ["ami-07ac2451de5d161f6"]
+    Amis        = [""]
   }
 }
 


### PR DESCRIPTION
Currently, attributes such as AMI types and EC2 sizes were defined by a configuration file that was used by the lambda function to display what choices were available. This PR aims to modify lambda logic to grab from the environment variable instead and allow user to define the choices through variables during the Turbo infrastructure deployment.

Moreover, two features were also added where users can define a route_53 zone for automatic A record registration and default user scripts to be ran on all instances deployed.

This PR is done with conjunction with this  [PR](https://github.com/frgrisk/turbo-deploy/pull/17) and has the same test plan