### PR TITLE
feat: added support for user defined filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ While there are a few variables that can be configured through the module, the b
 - ec2_attributes
 
     By default, server sizes are automatically set but not AMIs and so you need to configure them
+- image_filter_groups
+
+    The AMIs that are listed in the Turbo Deploy interface is configured through the use of filters that are used by the AWS API, you can look through the full list of filters in this [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html)
 
 ## Example
 
@@ -93,6 +96,36 @@ module "my_turbo_module" {
   ec2_attributes = {
     ServerSizes = ["t3.medium", "t3.large", "t3.xlarge"]
     Amis        = ["ami-0583d8c7a9c35822c", "ami-06338d230ffc3fc0c"]
+  }
+  image_filter_groups = {
+    "alma-ami" = [
+      {
+        name   = "is-public"
+        values = ["true"]
+      },
+      {
+        name   = "name"
+        values = ["AlmaLinux OS*"]
+      },
+      {
+        name   = "state"
+        values = ["available"]
+      }
+    ]
+    "redhat-ami" = [
+      {
+        name   = "is-public"
+        values = ["true"]
+      },
+      {
+        name   = "name"
+        values = ["RHEL-9.4.0*"]
+      },
+      {
+        name   = "state"
+        values = ["available"]
+      }
+    ]
   }
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -452,6 +452,7 @@ resource "aws_lambda_function" "database_lambda" {
       WEBSERVER_HOSTNAME   = var.turbo_deploy_hostname
       WEBSERVER_HTTP_PORT  = var.turbo_deploy_http_port
       WEBSERVER_HTTPS_PORT = var.turbo_deploy_https_port
+      AMI_FILTERS          = base64gzip(jsonencode(var.image_filter_groups))
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -140,34 +140,5 @@ variable "image_filter_groups" {
     name   = string
     values = list(string)
   })))
-  default = {
-    "redhat-ami" = [
-      {
-        name   = "is-public"
-        values = ["true"]
-      },
-      {
-        name   = "name"
-        values = ["AlmaLinux OS*"]
-      },
-      {
-        name   = "state"
-        values = ["available"]
-      }
-    ]
-    "user-ami" = [
-      {
-        name   = "is-public"
-        values = ["false"]
-      },
-      {
-        name   = "tag:DeployedBy"
-        values = ["turbo-deploy"]
-      },
-      {
-        name   = "state"
-        values = ["available"]
-      }
-    ]
-  }
+  default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -140,5 +140,20 @@ variable "image_filter_groups" {
     name   = string
     values = list(string)
   })))
-  default = null
+  default = {
+    "alma-ami" = [
+      {
+        name   = "is-public"
+        values = ["true"]
+      },
+      {
+        name   = "name"
+        values = ["AlmaLinux OS*"]
+      },
+      {
+        name   = "state"
+        values = ["available"]
+      }
+    ]
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,42 @@ variable "public_key" {
   type        = string
   default     = null
 }
+
+# filter types can be found here https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html
+variable "image_filter_groups" {
+  description = "Filter groups for different images"
+  type = map(list(object({
+    name   = string
+    values = list(string)
+  })))
+  default = {
+    "redhat-ami" = [
+      {
+        name   = "is-public"
+        values = ["true"]
+      },
+      {
+        name   = "name"
+        values = ["AlmaLinux OS*"]
+      },
+      {
+        name   = "state"
+        values = ["available"]
+      }
+    ]
+    "user-ami" = [
+      {
+        name   = "is-public"
+        values = ["false"]
+      },
+      {
+        name   = "tag:DeployedBy"
+        values = ["turbo-deploy"]
+      },
+      {
+        name   = "state"
+        values = ["available"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Previously, the filters used for determining what AMIs are shown in the frontend is hardcoded inside the lambda function. The aim of this PR is to make it so the user can define it from the turbo module.

This PR is tied to this [PR](https://github.com/frgrisk/turbo-deploy/pull/41) in the Turbo Deploy repository.