### PR TITLE
refactor: configure lambda to pull golang build from S3 instead of Github releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Before deploying the Turbo Infrastructure, there are a set of AWS resources that
 
     5. Run the script to create and push the image
 
-        `./deploy_lambda.sh`
+        `./deploy_ecr_image.sh`
   
 - S3 Bucket and associated zip file
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ While there are a few variables that can be configured through the module, the b
     The name of the ecr registry that you created and contains the image for the lambda function
 - s3_golang_bucket_name
 
-    The name that you will give to the S3 bucket that contains the zip file for the lambda function
+    The name of the S3 bucket that you created and contains the zip file for the lambda function
 - s3_golang_bucket_key
 
     The path to the zip file located in the S3 bucket specified in `s3_golang_bucket_name`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Before deploying the Turbo Infrastructure, there are a set of AWS resources that
 
     The lambda function that is responsible for the deployment works by retrieving an image from the ecr registry that contains the terraform code to run the instance deployment.
 
-    After you have created the ecr registry, the docker image will need to be manually created and pushed to the registry. To do so you may need to install docker and may then use the provided script from this [turbo repository](https://github.com/frgrisk/turbo-deploy) with the following steps:
+    After you have created the ecr registry, the docker image will need to be manually created and pushed to the registry. To do so you may need to install docker and may then use the provided script from the [frgrisk/turbo-deploy repository](https://github.com/frgrisk/turbo-deploy) with the following steps:
 
     1. Clone the turbo-deploy repository
 
@@ -49,6 +49,30 @@ Before deploying the Turbo Infrastructure, there are a set of AWS resources that
 
         `./deploy_lambda.sh`
   
+- S3 Bucket and associated zip file
+
+  The lambda function that acts as the API backend works by retrieving a zipfile that contains the golang build(named as a bootstrap file) from an S3 bucket.
+
+  After you have created the S3 bucket, the golang build will need to be manually built, zipped and uploaded to the S3 bucket. To do so, you may use the provided script from the [frgrisk/turbo-deploy repository](https://github.com/frgrisk/turbo-deploy) following these steps:
+
+  1. Clone the turbo-deploy repository
+
+        `git clone git@github.com:frgrisk/turbo-deploy.git`
+
+  2. Change the following values of the deploy_golang_binary.sh script to your environment
+
+      - S3_BUKCET=\<NAME OF YOUR S3 BUCKET\>
+      - S3_KEY=\<PATH TO THE GOLANG BUILD IN S3\>
+      - AWS_REGION=\<AWS REGION WHERE THE INFRASTRUCTURE WILL BE DEPLOYED\>
+
+  3. Configure the aws account keys in your terminal
+
+      `aws configure`
+
+  4. Run the script to create and push the image
+
+      `./deploy_golang_binary.sh`
+
 - Route53 Zone and registered domain
 
     The instances that are deployed through Turbo Deploy are meant to be accessible through the hostname that has been configured by the user, for this to work automatic registration of the hostname in an A record needs to be done.
@@ -62,9 +86,15 @@ While there are a few variables that can be configured through the module, the b
 - ecr_repository_name
 
     The name of the ecr registry that you created and contains the image for the lambda function
+- s3_golang_bucket_name
+
+    The name that you will give to the S3 bucket that contains the zip file for the lambda function
+- s3_golang_bucket_key
+
+    The path to the zip file located in the S3 bucket specified in `s3_golang_bucket_name`
 - s3_tf_bucket_name
 
-    The name that you will give to the S3 bucket (must be unique)
+    The name that you will give to the S3 bucket that acts as the terraform backend (must be unique)
 - zone_id
 
     The zone id of Route53 Zone
@@ -90,6 +120,8 @@ module "my_turbo_module" {
 
   source                   = "../terraform-aws-turbo-deploy"
   ecr_repository_name      = "turbo-image"
+  s3_golang_bucket_name = "turbo-deploy-lambda-zip-bucket"
+  s3_golang_bucket_key  = "lambda/lambda_function.zip"
   s3_tf_bucket_name        = "turbo-deploy-s3"
   zone_id                  = "Z23ABC4XYZL05B"
   turbo_deploy_hostname    = "turbodeploy-dev"

--- a/main.tf
+++ b/main.tf
@@ -455,7 +455,7 @@ resource "aws_lambda_function" "lambda_terraform_runner" {
   role          = aws_iam_role.terraform_lambda_role.arn
   function_name = var.terraform_lambda_function_name
   timeout       = 600
-  memory_size   = 512
+  memory_size   = 2048
 
   ephemeral_storage {
     size = 5612

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_api_gateway_integration" "lambda" {
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = aws_lambda_function.database_lambda.invoke_arn
+  uri                     = aws_lambda_function.lambda_api_backend.invoke_arn
 }
 
 // deploy the api gatway to activate the configuration and expose the API at a URL that can be used
@@ -81,7 +81,7 @@ resource "aws_api_gateway_stage" "dev" {
 resource "aws_lambda_permission" "apigw" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.database_lambda.function_name
+  function_name = aws_lambda_function.lambda_api_backend.function_name
   principal     = "apigateway.amazonaws.com"
 
   # The /*/* portion grants access from any method on any resource
@@ -94,7 +94,6 @@ resource "aws_lambda_permission" "apigw" {
 resource "aws_api_gateway_base_path_mapping" "base_path_mapping" {
   count       = var.api_gateway_domain_name != null && var.api_gateway_domain_name != "" ? 1 : 0
   api_id      = aws_api_gateway_rest_api.my_api_gateway.id
-  stage_name  = aws_api_gateway_deployment.my_api_deployment.stage_name
   domain_name = var.api_gateway_domain_name
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,7 +6,7 @@ output "terraform_locks_table_name" {
 }
 
 output "base_url" {
-  value       = aws_api_gateway_deployment.my_api_deployment.invoke_url
+  value       = aws_api_gateway_stage.dev.invoke_url
   description = "Url of the API gateway"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,16 @@ variable "s3_tf_bucket_name" {
   type        = string
 }
 
+variable "s3_golang_bucket_name" {
+  description = "name of the s3 bucket for the lambda with golang binary"
+  type        = string
+}
+
+variable "s3_golang_bucket_key" {
+  description = "key of the s3 object for the lambda with golang binary"
+  type        = string
+}
+
 variable "s3_force_destroy" {
   description = "option to force destroy s3"
   type        = bool
@@ -58,7 +68,7 @@ variable "api_gateway_domain_name" {
   default     = ""
 }
 
-variable "database_lambda_function_name" {
+variable "lambda_api_backend_name" {
   description = "Name of the lambda function stationed between API gateway and dynamoDB"
   type        = string
   default     = "MyGolangLambdaFunction"


### PR DESCRIPTION
Currently, the way that lambda retrieves the golang binary is by retrieving it from the github releases of the [Turbo Deploy repository](https://github.com/frgrisk/turbo-deploy). This is done by leveraging the `http` data source in Terraform to download the zip file.

However, that terraform data source does not expect binary data to be present and when it does it will throw out the warning below.
<img width="809" height="154" alt="image" src="https://github.com/user-attachments/assets/c8b7fc79-f92a-4beb-8691-accdaeae84b1" />

While its just a warning and does not affect the operation of the application, it is a bit annoying having an error that serves as noise that blocks our attention from identifying real errors. As such, the purpose of this PR is to modify the AWS Terraform lambda configuration to retrieve the zip file from a designated S3 bucket instead to remove the warning.

Besides that, this PR also removed the usage of the `stage_name` attribute from the `aws_api_gateway_base_path_mapping` to remove a deprecation warning and also increased the `memory_size` attribute of the terraform lambda function from 512MB to 2048MB due to an error caused by insufficient memory.

This PR is done in conjunction with this [PR](https://github.com/frgrisk/turbo-deploy/pull/138) from the turbo-deploy repository.