### PR TITLE
output lambda function arn to reference in terraform

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,3 +10,13 @@ output "base_url" {
   description = "Url of the API gateway"
 }
 
+output "golang_lambda_arn" {
+  description = "The ARN of the Golang Lambda function"
+  value       = aws_lambda_function.lambda_api_backend.arn
+}
+
+output "terraform_lambda_arn" {
+  description = "The ARN of the Terraform Lambda function"
+  value       = aws_lambda_function.lambda_terraform_runner.arn
+}
+


### PR DESCRIPTION
In order to set up permissions on the Lambda functions, we need to output their ARNs so that the relevant Terraform resources can reference them.