### PR TITLE
Create sns topic to inform admin when terraform apply fails

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -409,7 +409,7 @@ resource "aws_lambda_function" "lambda_terraform_runner" {
   }
   environment {
     variables = {
-      TF_LOG                     = "DEBUG",
+      TF_LOG                     = var.terraform_log
       AWS_STS_REGIONAL_ENDPOINTS = "regional"
       AWS_REGION_CUSTOM          = data.aws_region.current.name
       S3_BUCKET_NAME             = var.s3_tf_bucket_name

--- a/main.tf
+++ b/main.tf
@@ -411,6 +411,7 @@ resource "aws_lambda_function" "lambda_terraform_runner" {
       PUBLIC_KEY                 = aws_key_pair.admin_key.key_name
       PROFILE_NAME               = aws_iam_instance_profile.turbodeploy_profile.name
       USER_SCRIPTS               = jsonencode(keys(var.user_scripts))
+      SNS_TOPIC_ARN              = aws_sns_topic.terraform_failures.arn
     }
   }
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -269,6 +269,9 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
           "ec2:RunInstances",
           "ec2:DescribeInstances",
           "ec2:TerminateInstances",
+          "ec2:DescribeInstanceStatus",
+          "ec2:DescribeInstanceAttribute",
+          "ec2:DescribeInstanceCreditSpecifications",
           "ec2:ModifyInstanceAttribute",
           "ec2:DescribeInstanceTypes",
           "ec2:CreateTags",
@@ -286,6 +289,12 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
           "ec2:ReleaseAddress",
           "ec2:DescribeAddresses",
           "ec2:DescribeAddressesAttribute",
+          // EBS volumes
+          "ec2:CreateVolume",
+          "ec2:DeleteVolume",
+          "ec2:AttachVolume",
+          "ec2:DetachVolume",
+          "ec2:DescribeVolumes",
           // Snapshots
           "ec2:DescribeSnapshots",
           // AMIs

--- a/main.tf
+++ b/main.tf
@@ -170,9 +170,7 @@ resource "aws_iam_policy" "golang_lambda_policy" {
       {
         Effect = "Allow",
         "Action" : [
-          "ec2:RunInstances",
           "ec2:DescribeInstances",
-          "ec2:TerminateInstances",
           "ec2:StopInstances",
           "ec2:StartInstances",
           "ec2:RebootInstances",
@@ -183,32 +181,6 @@ resource "aws_iam_policy" "golang_lambda_policy" {
           "ec2:DescribeInstanceTypes",
           "ec2:CreateTags",
           "ec2:DescribeTags",
-          // Network interfaces
-          "ec2:DescribeVpcs",
-          "ec2:CreateNetworkInterface",
-          "ec2:DeleteNetworkInterface",
-          "ec2:AttachNetworkInterface",
-          "ec2:DetachNetworkInterface",
-          "ec2:DescribeNetworkInterfaces",
-          // Security groups
-          "ec2:DescribeSecurityGroups",
-          "ec2:CreateSecurityGroup",
-          "ec2:DeleteSecurityGroup",
-          "ec2:AuthorizeSecurityGroupIngress",
-          "ec2:RevokeSecurityGroupIngress",
-          "ec2:AuthorizeSecurityGroupEgress",
-          "ec2:RevokeSecurityGroupEgress",
-          // Elastic IPs
-          "ec2:AllocateAddress",
-          "ec2:AssociateAddress",
-          "ec2:DisassociateAddress",
-          "ec2:ReleaseAddress",
-          // EBS volumes
-          "ec2:CreateVolume",
-          "ec2:DeleteVolume",
-          "ec2:AttachVolume",
-          "ec2:DetachVolume",
-          "ec2:DescribeVolumes",
           // Snapshots
           "ec2:CreateSnapshot",
           "ec2:DeleteSnapshot",
@@ -217,10 +189,6 @@ resource "aws_iam_policy" "golang_lambda_policy" {
           "ec2:CreateImage",
           "ec2:DeregisterImage",
           "ec2:DescribeImages",
-          // Key pairs
-          "ec2:CreateKeyPair",
-          "ec2:DeleteKeyPair",
-          "ec2:DescribeKeyPairs",
           // Other
           "ec2:DescribeAvailabilityZones",
           //Spot requests
@@ -293,8 +261,7 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
           "ecr:BatchGetImage",
           "ecr:BatchCheckLayerAvailability",
         ],
-        # Resource = "${data.aws_ecr_repository.lambda_terraform_runner.arn}"
-        Resource = "*"
+        Resource = "${data.aws_ecr_repository.lambda_terraform_runner.arn}"
       },
       {
         Effect = "Allow",
@@ -302,12 +269,6 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
           "ec2:RunInstances",
           "ec2:DescribeInstances",
           "ec2:TerminateInstances",
-          "ec2:StopInstances",
-          "ec2:StartInstances",
-          "ec2:RebootInstances",
-          "ec2:DescribeInstanceStatus",
-          "ec2:DescribeInstanceAttribute",
-          "ec2:DescribeInstanceCreditSpecifications",
           "ec2:ModifyInstanceAttribute",
           "ec2:DescribeInstanceTypes",
           "ec2:CreateTags",
@@ -315,19 +276,9 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
           "ec2:DeleteTags",
           // Network interfaces
           "ec2:DescribeVpcs",
-          "ec2:CreateNetworkInterface",
-          "ec2:DeleteNetworkInterface",
-          "ec2:AttachNetworkInterface",
-          "ec2:DetachNetworkInterface",
           "ec2:DescribeNetworkInterfaces",
           // Security groups
           "ec2:DescribeSecurityGroups",
-          "ec2:CreateSecurityGroup",
-          "ec2:DeleteSecurityGroup",
-          "ec2:AuthorizeSecurityGroupIngress",
-          "ec2:RevokeSecurityGroupIngress",
-          "ec2:AuthorizeSecurityGroupEgress",
-          "ec2:RevokeSecurityGroupEgress",
           // Elastic IPs
           "ec2:AllocateAddress",
           "ec2:AssociateAddress",
@@ -335,24 +286,11 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
           "ec2:ReleaseAddress",
           "ec2:DescribeAddresses",
           "ec2:DescribeAddressesAttribute",
-          // EBS volumes
-          "ec2:CreateVolume",
-          "ec2:DeleteVolume",
-          "ec2:AttachVolume",
-          "ec2:DetachVolume",
-          "ec2:DescribeVolumes",
           // Snapshots
-          "ec2:CreateSnapshot",
-          "ec2:DeleteSnapshot",
           "ec2:DescribeSnapshots",
           // AMIs
-          "ec2:CreateImage",
-          "ec2:DeregisterImage",
           "ec2:DescribeImages",
-          // Key pairs
-          "ec2:ImportKeyPair",
-          "ec2:CreateKeyPair",
-          "ec2:DeleteKeyPair",
+          // Key pairs,
           "ec2:DescribeKeyPairs",
           // Other
           "ec2:DescribeAvailabilityZones",

--- a/sns.tf
+++ b/sns.tf
@@ -8,3 +8,22 @@ resource "aws_sns_topic_subscription" "email_subscription" {
   protocol  = "email"
   endpoint  = var.admin_email
 }
+
+# Define the policy as a data source
+data "aws_iam_policy_document" "sns_publish_policy" {
+  statement {
+    effect    = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.terraform_lambda_role]
+    }
+    actions   = ["SNS:Publish"]
+    resources = [aws_sns_topic.terraform_failures.arn]
+  }
+}
+
+# Attach the policy to the SNS topic
+resource "aws_sns_topic_policy" "allow_publish" {
+  arn    = aws_sns_topic.terraform_failures.arn
+  policy = data.aws_iam_policy_document.sns_publish_policy.json
+}

--- a/sns.tf
+++ b/sns.tf
@@ -1,0 +1,10 @@
+resource "aws_sns_topic" "terraform_failures" {
+  name = "terraform-failures-topic"
+}
+
+resource "aws_sns_topic_subscription" "email_subscription" {
+  count     = var.admin_email ? 1 : 0
+  topic_arn = aws_sns_topic.terraform_failures.arn
+  protocol  = "email"
+  endpoint  = var.admin_email
+}

--- a/sns.tf
+++ b/sns.tf
@@ -12,7 +12,7 @@ resource "aws_sns_topic_subscription" "email_subscription" {
 # Define the policy as a data source
 data "aws_iam_policy_document" "sns_publish_policy" {
   statement {
-    effect    = "Allow"
+    effect = "Allow"
     principals {
       type        = "AWS"
       identifiers = [aws_iam_role.terraform_lambda_role]

--- a/sns.tf
+++ b/sns.tf
@@ -3,7 +3,7 @@ resource "aws_sns_topic" "terraform_failures" {
 }
 
 resource "aws_sns_topic_subscription" "email_subscription" {
-  count     = var.admin_email ? 1 : 0
+  count     = var.admin_email != null && var.admin_email != "" ? 1 : 0
   topic_arn = aws_sns_topic.terraform_failures.arn
   protocol  = "email"
   endpoint  = var.admin_email
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "sns_publish_policy" {
     effect = "Allow"
     principals {
       type        = "AWS"
-      identifiers = [aws_iam_role.terraform_lambda_role]
+      identifiers = [aws_iam_role.terraform_lambda_role.arn]
     }
     actions   = ["SNS:Publish"]
     resources = [aws_sns_topic.terraform_failures.arn]

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,12 @@ variable "public_key" {
   default     = null
 }
 
+variable "admin_email" {
+  description = "The email to send to when a failure is detected with the terraform apply process"
+  type        = string
+  default     = null
+}
+
 # filter types can be found here https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html
 variable "image_filter_groups" {
   description = "Filter groups for different images"

--- a/variables.tf
+++ b/variables.tf
@@ -159,6 +159,12 @@ variable "admin_email" {
   default     = null
 }
 
+variable "terraform_log" {
+  description = "The log level for terraform execution"
+  type        = string
+  default     = "ERROR"
+}
+
 # filter types can be found here https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html
 variable "image_filter_groups" {
   description = "Filter groups for different images"


### PR DESCRIPTION
Right now, the only way for users and admins to know if the Terraform apply step in the Lambda function fails is by manually checking the CloudWatch logs. This can be a bit tedious since there’s no quick way to tell whether a deployment succeeded without digging through the logs.

This PR adds an SNS topic that admins can subscribe to, which will send an email notification whenever a Terraform apply fails. That way, issues are easier to spot right away without needing to hunt through logs.

This PR is done in conjunction with this [PR](https://github.com/frgrisk/turbo-deploy/pull/152).

Besides that, this PR also makes some minor changes where:

- We can now configure the value of the terraform logging.
- Removed some lambda policy that is not required.