### PR TITLE
refactor: allow multiple people to be subscribed to the terraform failure sns topic

### DIFF
--- a/sns.tf
+++ b/sns.tf
@@ -3,10 +3,10 @@ resource "aws_sns_topic" "terraform_failures" {
 }
 
 resource "aws_sns_topic_subscription" "email_subscription" {
-  count     = var.admin_email != null && var.admin_email != "" ? 1 : 0
+  for_each = toset(var.tf_failure_emails)
   topic_arn = aws_sns_topic.terraform_failures.arn
   protocol  = "email"
-  endpoint  = var.admin_email
+  endpoint  = each.value
 }
 
 # Define the policy as a data source

--- a/sns.tf
+++ b/sns.tf
@@ -3,7 +3,7 @@ resource "aws_sns_topic" "terraform_failures" {
 }
 
 resource "aws_sns_topic_subscription" "email_subscription" {
-  for_each = toset(var.tf_failure_emails)
+  for_each  = toset(var.tf_failure_emails)
   topic_arn = aws_sns_topic.terraform_failures.arn
   protocol  = "email"
   endpoint  = each.value

--- a/variables.tf
+++ b/variables.tf
@@ -153,10 +153,10 @@ variable "public_key" {
   default     = null
 }
 
-variable "admin_email" {
+variable "tf_failure_emails" {
   description = "The email to send to when a failure is detected with the terraform apply process"
-  type        = string
-  default     = null
+  type        = list(string)
+  default     = []
 }
 
 variable "terraform_log" {


### PR DESCRIPTION
Currently only one email can be used to subscribe to the sns topic that informs users of terraform failures, the purpose of this PR is to allow multiple people to be able to be subscribed to it instead.