### PR TITLE
refactor: add maximum retry attempts for terraform lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -433,6 +433,11 @@ resource "aws_lambda_event_source_mapping" "terraform_event_mapping" {
   event_source_arn  = aws_dynamodb_table.http_crud_backend.stream_arn
   function_name     = aws_lambda_function.lambda_terraform_runner.arn
   starting_position = "LATEST"
+  maximum_retry_attempts = 1
+
+  tags = {
+    Name = "dynamodb-stream-mapping"
+  }
 }
 
 resource "aws_s3_object" "userdata_upload" {

--- a/main.tf
+++ b/main.tf
@@ -430,9 +430,9 @@ resource "aws_lambda_function" "lambda_terraform_runner" {
 }
 
 resource "aws_lambda_event_source_mapping" "terraform_event_mapping" {
-  event_source_arn  = aws_dynamodb_table.http_crud_backend.stream_arn
-  function_name     = aws_lambda_function.lambda_terraform_runner.arn
-  starting_position = "LATEST"
+  event_source_arn       = aws_dynamodb_table.http_crud_backend.stream_arn
+  function_name          = aws_lambda_function.lambda_terraform_runner.arn
+  starting_position      = "LATEST"
   maximum_retry_attempts = 1
 
   tags = {


### PR DESCRIPTION
With how DynamoDB’s Lambda event source mapping works, when a Lambda invocation fails, DynamoDB will automatically retry it. By default, this retry can happen indefinitely with no limit.

This ended up causing issues for users, since the Lambda SNS topic would keep sending notifications over and over until the problematic DynamoDB record was removed.

The purpose of this PR is to limit the retry invocation to a single time.