### PR TITLE
fix: terraform lambda missing required ami permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -267,6 +267,9 @@ resource "aws_iam_policy" "terraform_lambda_policy" {
         Effect = "Allow",
         "Action" : [
           "ec2:RunInstances",
+          "ec2:StopInstances",
+          "ec2:StartInstances",
+          "ec2:RebootInstances",
           "ec2:DescribeInstances",
           "ec2:TerminateInstances",
           "ec2:DescribeInstanceStatus",


### PR DESCRIPTION
Due to an earlier editing oversight, the Terraform Lambda function lost the AMI permissions required to restart the instances. This PR restores the necessary permissions to ensure the Lambda function can perform restarts as intended.