### PR TITLE
refactor: Allow multiple security groups for ec2 deployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -417,7 +417,7 @@ resource "aws_lambda_function" "lambda_terraform_runner" {
       AWS_REGION_CUSTOM          = data.aws_region.current.name
       S3_BUCKET_NAME             = var.s3_tf_bucket_name
       DYNAMODB_TABLE             = var.dynamodb_tf_locks_name
-      SECURITY_GROUP_ID          = var.security_group_id != null ? var.security_group_id : ""
+      SECURITY_GROUP_IDS         = jsonencode(var.security_group_ids)
       PUBLIC_SUBNET_ID           = length(var.public_subnet_ids) > 0 ? element(var.public_subnet_ids, 0) : ""
       HOSTED_ZONE_ID             = var.zone_id
       PUBLIC_KEY                 = aws_key_pair.admin_key.key_name

--- a/variables.tf
+++ b/variables.tf
@@ -4,10 +4,10 @@ variable "ecr_repository_name" {
   default     = null
 }
 
-variable "security_group_id" {
+variable "security_group_ids" {
   description = "id of security group associated with ec2 deployment"
-  type        = string
-  default     = null
+  type        = list(string)
+  default     = []
 }
 
 variable "public_subnet_ids" {


### PR DESCRIPTION
Currently only one security group can be configured for instances created using Turbo Deploy, the purpose of this PR is to allow more than one security group to be defined.

This is done in conjunction with this [PR](https://github.com/frgrisk/turbo-deploy/pull/161)