### PR TITLE
refactor: Configure multi region deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,28 +85,27 @@ While there are a few variables that can be configured through the module, the b
 
 - ecr_repository_name
 
-    The name of the ecr registry that you created and contains the image for the lambda function
+    The name of the ecr registry that you created and contains the image for the lambda function.
 - s3_golang_bucket_name
 
-    The name of the S3 bucket that you created and contains the zip file for the lambda function
+    The name of the S3 bucket that you created and contains the zip file for the lambda function.
 - s3_golang_bucket_key
 
-    The path to the zip file located in the S3 bucket specified in `s3_golang_bucket_name`
+    The path to the zip file located in the S3 bucket specified in `s3_golang_bucket_name`.
 - s3_tf_bucket_name
 
-    The name that you will give to the S3 bucket that acts as the terraform backend (must be unique)
+    The name that you will give to the S3 bucket that acts as the terraform backend (must be unique).
 - zone_id
 
-    The zone id of Route53 Zone
+    The zone id of Route53 Zone.
 - turbo_deploy_hostname
 
-    The hostname of the instance that will host the Turbo Deploy Web Application
-- ec2_attributes
+    The hostname of the instance that will host the Turbo Deploy Web Application.
+- deployment_config
 
-    By default, server sizes are automatically set but not AMIs and so you need to configure them
-- image_filter_groups
+    This configuration defines the instance types and machine images available for the specified region. It also requires the subnet ID where the instances will be deployed, along with the security groups that should be attached to them. Additionally, you must specify the key pair name in that region to enable SSH access to the instances.
 
-    The AMIs that are listed in the Turbo Deploy interface is configured through the use of filters that are used by the AWS API, you can look through the full list of filters in this [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html)
+    The AMIs that are listed in the Turbo Deploy interface is configured through the use of filters that are used by the AWS API, you can look through the full list of filters in this [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html).
 
 ## Example
 
@@ -118,46 +117,55 @@ module "my_turbo_module" {
     aws = aws
   }
 
-  source                   = "../terraform-aws-turbo-deploy"
-  ecr_repository_name      = "turbo-image"
-  s3_golang_bucket_name = "turbo-deploy-lambda-zip-bucket"
-  s3_golang_bucket_key  = "lambda/lambda_function.zip"
+  source                   = "git::https://github.com/frgrisk/terraform-aws-turbo-deploy.git"
+  ecr_repository_name      = "turbo-deploy-tf-function"
+  s3_golang_bucket_name    = "turbo-deploy-lambda-zip-bucket"
+  s3_golang_bucket_key     = "lambda/lambda_function.zip"
   s3_tf_bucket_name        = "turbo-deploy-s3"
   zone_id                  = "Z23ABC4XYZL05B"
-  turbo_deploy_hostname    = "turbodeploy-dev"
-  ec2_attributes = {
-    ServerSizes = ["t3.medium", "t3.large", "t3.xlarge"]
-    Amis        = ["ami-0583d8c7a9c35822c", "ami-06338d230ffc3fc0c"]
-  }
-  image_filter_groups = {
-    "alma-ami" = [
-      {
-        name   = "is-public"
-        values = ["true"]
-      },
-      {
-        name   = "name"
-        values = ["AlmaLinux OS*"]
-      },
-      {
-        name   = "state"
-        values = ["available"]
+  turbo_deploy_hostname    = "turbodeploy-host"
+  deployment_config = {
+    "us-east-2" = {
+      compute = {
+        ami_filter_groups = {
+          "alma10-ami" = [
+            { name = "is-public", values = ["true"] },
+            { name = "name", values = ["AlmaLinux OS 10.0.*"] },
+            { name = "state", values = ["available"] }
+          ]
+          "alma8-ami" = [
+            { name = "is-public", values = ["true"] },
+            { name = "name", values = ["AlmaLinux OS 8.*"] },
+            { name = "state", values = ["available"] }
+          ]
+        }
+        instance_types = ["t3.micro", "t3.small"]
       }
-    ]
-    "redhat-ami" = [
-      {
-        name   = "is-public"
-        values = ["true"]
-      },
-      {
-        name   = "name"
-        values = ["RHEL-9.4.0*"]
-      },
-      {
-        name   = "state"
-        values = ["available"]
+
+      network = {
+        subnet_id          = "subnet-aaaaaa"
+        security_group_ids = ["sg-bbbbbbbbbbb"]
+        key_name           = "turbo-deploy-testing-ohio"
       }
-    ]
+    }
+    "ap-southeast-5" = {
+      compute = {
+        ami_filter_groups = {
+          "alma9-ami" = [
+            { name = "is-public", values = ["true"] },
+            { name = "name", values = ["AlmaLinux OS 9.*"] },
+            { name = "state", values = ["available"] }
+          ]
+        }
+        instance_types = ["t4g.micro", "t4g.small"]
+      }
+
+      network = {
+        subnet_id          = "subnet-cccccccccc"
+        security_group_ids = ["sg-ddddddddddd", "sg-eeeeeeeee"]
+        key_name           = "turbo-deploy-testing-malaysia"
+      }
+    }
   }
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,17 @@ terraform {
   }
 }
 
+locals {
+  lambda_deployment_config = {
+    for region, cfg in var.deployment_config :
+    region => cfg.compute
+  }
+  terraform_deployment_config = {
+    for region, cfg in var.deployment_config :
+    region => cfg.network
+  }
+}
+
 data "aws_region" "current" {}
 
 // retrieve the zone name
@@ -382,14 +393,12 @@ resource "aws_lambda_function" "lambda_api_backend" {
   environment {
     variables = {
       MY_CUSTOM_ENV        = "Lambda"
-      MY_AMI_ATTR          = jsonencode(var.ec2_attributes)
-      MY_REGION            = data.aws_region.current.name
+      DEPLOYMENT_CONFIG    = base64gzip(jsonencode(local.lambda_deployment_config))
       ROUTE53_DOMAIN_NAME  = data.aws_route53_zone.zone_name.name
       WEBSERVER_HOSTNAME   = var.turbo_deploy_hostname
       WEBSERVER_HTTP_PORT  = var.turbo_deploy_http_port
       WEBSERVER_HTTPS_PORT = var.turbo_deploy_https_port
       USER_SCRIPTS         = jsonencode(keys(var.user_scripts))
-      AMI_FILTERS          = base64gzip(jsonencode(var.image_filter_groups))
     }
   }
 }
@@ -413,14 +422,12 @@ resource "aws_lambda_function" "lambda_terraform_runner" {
   environment {
     variables = {
       TF_LOG                     = var.terraform_log
+      NETWORK_CONFIG             = base64encode(jsonencode(local.terraform_deployment_config))
       AWS_STS_REGIONAL_ENDPOINTS = "regional"
       AWS_REGION_CUSTOM          = data.aws_region.current.name
       S3_BUCKET_NAME             = var.s3_tf_bucket_name
       DYNAMODB_TABLE             = var.dynamodb_tf_locks_name
-      SECURITY_GROUP_IDS         = jsonencode(var.security_group_ids)
-      PUBLIC_SUBNET_ID           = length(var.public_subnet_ids) > 0 ? element(var.public_subnet_ids, 0) : ""
       HOSTED_ZONE_ID             = var.zone_id
-      PUBLIC_KEY                 = aws_key_pair.admin_key.key_name
       PROFILE_NAME               = var.instance_profile
       USER_SCRIPTS               = jsonencode(keys(var.user_scripts))
       SNS_TOPIC_ARN              = aws_sns_topic.terraform_failures.arn
@@ -456,9 +463,4 @@ resource "aws_s3_object" "base_userdata_upload" {
   key          = "user-data-base/base.sh"
   content_type = "text/plain"
   content      = var.base_script
-}
-
-resource "aws_key_pair" "admin_key" {
-  key_name   = "admin_key"
-  public_key = var.public_key
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,18 +4,6 @@ variable "ecr_repository_name" {
   default     = null
 }
 
-variable "security_group_ids" {
-  description = "id of security group associated with ec2 deployment"
-  type        = list(string)
-  default     = []
-}
-
-variable "public_subnet_ids" {
-  description = "ids of public subnet associated with ec2 deployment"
-  type        = list(string)
-  default     = []
-}
-
 // not even sure if s3 can have a default name
 variable "s3_tf_bucket_name" {
   description = "name of the s3 bucket for the lambda with terraform binary"
@@ -98,15 +86,6 @@ variable "terraform_lambda_function_name" {
   default     = "MyTerraformFunction"
 }
 
-variable "ec2_attributes" {
-  description = "EC2 attributes that can be modified (e.g. AMI, Server Type, etc...)"
-  type        = map(list(string))
-  default = {
-    ServerSizes = ["t3.medium"]
-    Amis        = ["ami-07ac2451de5d161f6"]
-  }
-}
-
 variable "user_scripts" {
   description = "The userdata to display as choices and use when launching the instance"
   type        = map(string)
@@ -147,12 +126,6 @@ variable "turbo_deploy_https_port" {
   default     = "4443"
 }
 
-variable "public_key" {
-  description = "The default public key to be added to all deployed instances"
-  type        = string
-  default     = null
-}
-
 variable "tf_failure_emails" {
   description = "The email to send to when a failure is detected with the terraform apply process"
   type        = list(string)
@@ -166,28 +139,23 @@ variable "terraform_log" {
 }
 
 # filter types can be found here https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html
-variable "image_filter_groups" {
-  description = "Filter groups for different images"
-  type = map(list(object({
-    name   = string
-    values = list(string)
-  })))
-  default = {
-    "alma-ami" = [
-      {
-        name   = "is-public"
-        values = ["true"]
-      },
-      {
-        name   = "name"
-        values = ["AlmaLinux OS*"]
-      },
-      {
-        name   = "state"
-        values = ["available"]
-      }
-    ]
-  }
+variable "deployment_config" {
+  description = "Region-specific compute and network configuration"
+
+  type = map(object({
+    compute = object({
+      ami_filter_groups = map(list(object({
+        name   = string
+        values = list(string)
+      })))
+      instance_types = list(string)
+    })
+    network = object({
+      subnet_id          = string
+      security_group_ids = list(string)
+      key_name           = string
+    })
+  }))
 }
 
 variable "instance_profile" {


### PR DESCRIPTION
Currently, Turbo Deploy supports deploying instances only within a single region specifically being the region where the Turbo Deploy infrastructure itself is hosted.

The purpose of this PR is to extend Turbo Deploy’s functionality to support multi-region deployments, allowing instances to be deployed across multiple AWS regions.

The primary change introduced in this PR is a restructuring of how configuration inputs are defined. Previously, deployment options were split across multiple variables, such as ec2_attributes and image_filter_groups. These have now been consolidated into a single variable named deployment_config.

This change centers the configuration around regions. Since available AWS resources (e.g., instance types, AMIs, subnets, and security groups) differ between regions, grouping configuration by region provides a clearer structure for multi-region support.

This PR is done in conjunction with this [PR](https://github.com/frgrisk/turbo-deploy/pull/166) in the turbo-deploy repository.